### PR TITLE
install pandoc in python-docs

### DIFF
--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -18,5 +18,10 @@ jobs:
           python-version: ${{ inputs.python-version }}
           install-extras: "doc"
 
+      - name: Install pandoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
+
       - name: Build documentation
         run: sphinx-build ./doc ./html


### PR DESCRIPTION
It was installed by default on the Gitlab CI docker runners, now it is missing. So far used in `ewoks`.